### PR TITLE
adds post about currying agents

### DIFF
--- a/site/src/data/blog/curry-agents.md
+++ b/site/src/data/blog/curry-agents.md
@@ -1,3 +1,18 @@
+---
+author: Björn Roberg, Claude
+pubDatetime: 2026-02-11T04:00:00Z
+modDatetime: 2026-02-11T04:00:00Z
+title: Currying agents
+slug: currying-agents
+featured: true
+draft: false
+tags:
+  - tool
+  - computing
+  - agents
+description: How one can leverage partial application of agents - borrowing from the functional programming paradigm.
+---
+
 **Currying in LLM agents means breaking down a complex agent task into a chain of smaller, specialized functions where each step takes some inputs and returns a new function waiting for the next piece of information.**
 
 ---


### PR DESCRIPTION
This pull request introduces a new blog post on currying in LLM agents and replaces the content of `scratch.md` with a detailed explanation of the same topic. The changes provide a comprehensive overview of how currying, a concept from functional programming, can be applied to large language model agents for progressive context building, modularity, and improved agent workflows.

**New content about currying in LLM agents:**

* Added a new blog post `curry-agents.md` that explains the concept of currying in LLM agents, including practical applications, technical implementation patterns, benefits, and advanced agentic workflow patterns.
* Replaced the previous concrete example in `scratch.md` with the same detailed currying-in-agents content, ensuring consistency and broader exposure of the topic.

**Key themes covered in both files:**

Currying and context building:
* Explains how currying transforms agent tasks into chains of specialized functions, enabling progressive context accumulation and modular agent design. [[1]](diffhunk://#diff-4441eb07b9e44a32eb3dcae586f53c60d19c54671c38045c87da85747a780f11R1-R184) [[2]](diffhunk://#diff-377e2d8d5a2d6062abf5dcd3d04e9c9df2e379aa7946bb7f9cd13033229e49dfL1-R169)

Practical and technical patterns:
* Provides examples of sequential context refinement, tool binding, multi-stage reasoning, closure-based context accumulation, dependency injection, and prompt template composition for agent development. [[1]](diffhunk://#diff-4441eb07b9e44a32eb3dcae586f53c60d19c54671c38045c87da85747a780f11R1-R184) [[2]](diffhunk://#diff-377e2d8d5a2d6062abf5dcd3d04e9c9df2e379aa7946bb7f9cd13033229e49dfL1-R169)

Benefits and workflow applications:
* Discusses reusability, composability, testability, lazy evaluation, type safety, and separation of concerns, as well as advanced patterns like agentic pipelines and guidance on when to use currying in agent systems. [[1]](diffhunk://#diff-4441eb07b9e44a32eb3dcae586f53c60d19c54671c38045c87da85747a780f11R1-R184) [[2]](diffhunk://#diff-377e2d8d5a2d6062abf5dcd3d04e9c9df2e379aa7946bb7f9cd13033229e49dfL1-R169)